### PR TITLE
Added unit test for mostSimilarTS.py, Tested coverage on local drive

### DIFF
--- a/timeseries/tests/test_mostSimilarTS.py
+++ b/timeseries/tests/test_mostSimilarTS.py
@@ -1,0 +1,17 @@
+import generateAndStoreTS, TimeSeriesDistance, buildVPDBforest, mostSimilarTS, pickle
+import unittest
+
+generateAndStoreTS.generateAndStoreTimeSeries()
+
+VPDBList = buildVPDBforest.createVPForest()
+
+
+class MyTest(unittest.TestCase):
+    # all of them have test_xxx so that unittest main can run it
+    
+    def mostSimilarTS(self, inputFileName, VPDict, howmany = 1):
+        self.assertEqual(mostSimilarTS.mostSimilarTS('./ts_1.npy', VPDBList[0].VPDict, 1), ['./ts_1.npy'])
+    
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
File 'test_mostSimilarTS.py' added.

Output from unit test from local drive shown below.

=========================================================================== test session starts ====
platform darwin -- Python 3.5.2, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /Users/chinhuichew/Documents/Data Science/CS207/Paired Team Git Local/paired_team_repo_cs207project-1, inifile: setup.cfg
plugins: cov-2.3.1
collected 75 items 

ArrayTimeSeries.py .
SimulatedTimeSeries.py .
TimeSeries.py .
mostSimilarTS.py .
tests/test_ArrayTimeSeries.py ..........................
tests/test_Interface.py ............
tests/test_SimulatedTimeSeries.py .......
tests/test_TimeSeries.py ..........................Coverage.py warning: Module timeseries/ was never imported.


---------- coverage: platform darwin, python 3.5.2-final-0 -----------
Name               Stmts   Miss  Cover   Missing
------------------------------------------------
mostSimilarTS.py      41      0   100%